### PR TITLE
Adds a dockerignore example to the guide

### DIFF
--- a/stack/docker/README.md
+++ b/stack/docker/README.md
@@ -58,3 +58,7 @@ host cluster using [Swarm](https://docs.docker.com/swarm/) to manage all the ava
 * Most of the time it is because they've invested so
 much money on their own infrastructure, they are not willing to use/pay another
 provider, even if the provider is cheaper and more reliable!
+
+## .dockerignore samples
+
+* [Linux](dockerignore_linux)

--- a/stack/docker/dockerignore_linux
+++ b/stack/docker/dockerignore_linux
@@ -1,0 +1,17 @@
+# git files
+.git
+.gitignore
+
+# Documentation
+README.md
+
+# Rails
+.env
+log
+tmp
+
+# Bash
+.bash_history
+
+# Other
+.dockerignore


### PR DESCRIPTION
#59 Adds a basic .dockerignore example file. 