### PR TITLE
Initial Code Reviewer's Guide

### DIFF
--- a/best_practices/CODE_REVIEWER_GUIDE.md
+++ b/best_practices/CODE_REVIEWER_GUIDE.md
@@ -4,9 +4,19 @@
 
 Whenever any of these fails, stop the review and ask the developer to fix the issue.
 
-- It's base is `master` or any `epic` branch? *We shouldn't even spend time on PR's not based on any of these two.*
+- The PR base must be `master` or any `epic` branch. *We shouldn't even spend time on PR's not based on any of these two.*
 
-  - If it is an `epic` branch, does it have a pending Pull Request? *We might end up accepting changes without visibility to the team*
+  - If it is an `epic` branch, there must be a pending PR on it. *We might end up accepting changes without visibility to the team if the epic's PR is missing*
+
+- The size of the changes in the PR must not exceed:
+
+  - ~ 200 added/changed LOCs for "fix" PR's
+
+  - ~ 400 added/changed LOC's for "feature" PR's
+
+- The PR should only include 1 feature to add, or 1 bug to fix. *Check the description to see which feature the PR is adding**
+
+- The description should match the changes you see in the diff.
 
 - Code is up-to-date with the base branch? *We might end up reviewing & accepting code that is not yet finished (because it's still subject to change*
 

--- a/best_practices/CODE_REVIEWER_GUIDE.md
+++ b/best_practices/CODE_REVIEWER_GUIDE.md
@@ -4,7 +4,10 @@
 
 Whenever any of these fails, stop the review and ask the developer to fix the issue.
 
-- [ ] It's base is "master" or any "epic" branch? We shouldn't even spend time on PR's not based on any of these two.
-  - [ ] If it is an "epic" branch, does it have a pending Pull Request? If not, we might end up accepting changes without visibility to the team.
-- [ ] Code is up-to-date with the base branch? If not, we might end up reviewing & accepting code that is not yet finished (because it's still subject to change)
-- [ ] Tests & other build processes are all passing?
+- It's base is `master` or any `epic` branch? *We shouldn't even spend time on PR's not based on any of these two.*
+
+  - If it is an `epic` branch, does it have a pending Pull Request? *We might end up accepting changes without visibility to the team*
+
+- Code is up-to-date with the base branch? *We might end up reviewing & accepting code that is not yet finished (because it's still subject to change*
+
+- Tests & other build processes are all passing?

--- a/best_practices/CODE_REVIEWER_GUIDE.md
+++ b/best_practices/CODE_REVIEWER_GUIDE.md
@@ -9,12 +9,10 @@ Whenever any of these fails, stop the review and ask the developer to fix the is
   - If it is an `epic` branch, there must be a pending PR on it. *We might end up accepting changes without visibility to the team if the epic's PR is missing*
 
 - The size of the changes in the PR must not exceed:
+  - ~ 200 added/changed LOCs for "fix" PR's
+  - ~ 400 added/changed LOC's for "feature" PR's
 
-  - ~ 200 added/changed LOCs for "fix" PR's
-
-  - ~ 400 added/changed LOC's for "feature" PR's
-
-- The PR should only include 1 feature to add, or 1 bug to fix. *Check the description to see which feature the PR is adding**
+- The PR should only include 1 feature to add, or 1 bug to fix. *Check the description to see which feature the PR is adding to base*
 
 - The description should match the changes you see in the diff.
 
@@ -34,3 +32,13 @@ We will start automating some of these, either via HoundCI or Foresight
 * When there is room for improving, indicate what the current code is lacking of, what the problems are, and give ideas on how to improve.
 
 * When requesting changes, enumerate the main TODOs in the final comment.
+
+## Accept PR checklist
+
+When a PR is finally ready to be accepted:
+
+* Include a cool, encouraging final comment. Maybe also further reading/actions.
+
+* **Use squash & merge **
+
+* Delete the branch **ONLY** if the accepted PR screen on Github allows you to do it. Never nuke it directly from Git (i.e. using `git push --delete origin the-branch`)

--- a/best_practices/CODE_REVIEWER_GUIDE.md
+++ b/best_practices/CODE_REVIEWER_GUIDE.md
@@ -39,6 +39,6 @@ When a PR is finally ready to be accepted:
 
 * Include a cool, encouraging final comment. Maybe also further reading/actions.
 
-* **Use squash & merge **
+* **Use squash & merge**
 
 * Delete the branch **ONLY** if the accepted PR screen on Github allows you to do it. Never nuke it directly from Git (i.e. using `git push --delete origin the-branch`)

--- a/best_practices/CODE_REVIEWER_GUIDE.md
+++ b/best_practices/CODE_REVIEWER_GUIDE.md
@@ -1,0 +1,10 @@
+# Code Reviewer Guide
+
+## Checklist
+
+Whenever any of these fails, stop the review and ask the developer to fix the issue.
+
+- [ ] It's base is "master" or any "epic" branch? We shouldn't even spend time on PR's not based on any of these two.
+  - [ ] If it is an "epic" branch, does it have a pending Pull Request? If not, we might end up accepting changes without visibility to the team.
+- [ ] Code is up-to-date with the base branch? If not, we might end up reviewing & accepting code that is not yet finished (because it's still subject to change)
+- [ ] Tests & other build processes are all passing?

--- a/best_practices/CODE_REVIEWER_GUIDE.md
+++ b/best_practices/CODE_REVIEWER_GUIDE.md
@@ -21,3 +21,16 @@ Whenever any of these fails, stop the review and ask the developer to fix the is
 - Code is up-to-date with the base branch? *We might end up reviewing & accepting code that is not yet finished (because it's still subject to change*
 
 - Tests & other build processes are all passing?
+
+## Code Review Guidelines
+
+We will start automating some of these, either via HoundCI or Foresight
+
+* When there is a coding style issue, have a link to the guideline detail. For example:
+   "[Avoid outer braces and parentheses for DSL methods](https://github.com/bbatsov/ruby-style-guide#no-dsl-decorating)"
+
+* When there is a coding bad practice, be sure to refer exactly which lines are bad, and include an example of the "good" way.
+
+* When there is room for improving, indicate what the current code is lacking of, what the problems are, and give ideas on how to improve.
+
+* When requesting changes, enumerate the main TODOs in the final comment.

--- a/best_practices/CODE_REVIEWER_GUIDE.md
+++ b/best_practices/CODE_REVIEWER_GUIDE.md
@@ -1,6 +1,6 @@
 # Code Reviewer Guide
 
-## Checklist
+## Pre-flight Checklist
 
 Whenever any of these fails, stop the review and ask the developer to fix the issue.
 


### PR DESCRIPTION
This is a first version of the document.

### What does this PR do?

* Creates a guide for code reviewers at IcaliaLabs, with a checklist of stuff we need to double-check before reviewing a PR.
