### PR TITLE
Set the ESLint indent rule to 2 spaces

### DIFF
--- a/best_practices/code-analysis/default.eslintrc.yml
+++ b/best_practices/code-analysis/default.eslintrc.yml
@@ -2,7 +2,7 @@ extends:
     "eslint:recommended"
 
 rules:
-    indent: [2, 4, {SwitchCase: 1}]
+    indent: ["error", 2, {SwitchCase: 1}]
     block-spacing: 2
     brace-style: [2, "1tbs"]
     camelcase: [2, { properties: "never" }]


### PR DESCRIPTION
### What does this PR do?

* After discussion on #82, we decided to enforce the 2-space indentation on Javascript files.

[Closes #81]