### PR TITLE
Eslint rules proposal

### DIFF
--- a/best_practices/code-analysis/default.eslintrc.yml
+++ b/best_practices/code-analysis/default.eslintrc.yml
@@ -1,6 +1,17 @@
-extends:
-    "eslint:recommended"
+extends: ["eslint:recommended"]
 
+parser: "babel-eslint"
+
+parserOptions:
+    ecmaVersion: 6
+    sourceType: "module"
+
+env:
+    es6: true
+    browser: true
+    node: true
+    jest: true
+    
 rules:
     indent: ["error", 2, {SwitchCase: 1}]
     block-spacing: 2
@@ -15,7 +26,7 @@ rules:
     dot-notation: [2, { allowKeywords: true }]
     eol-last: 2
     eqeqeq: 2
-    func-style: [2, "declaration"]
+    func-style: 0
     guard-for-in: 2
     key-spacing: [2, { beforeColon: false, afterColon: true }]
     new-cap: 2
@@ -25,7 +36,6 @@ rules:
     no-caller: 2
     no-console: 0
     no-delete-var: 2
-    no-empty-label: 2
     no-eval: 2
     no-extend-native: 2
     no-extra-bind: 2
@@ -70,14 +80,13 @@ rules:
     no-with: 2
     quotes: [2, "double"]
     radix: 2
-    require-jsdoc: 2
+    require-jsdoc: 0
     semi: 2
     semi-spacing: [2, {before: false, after: true}]
-    space-after-keywords: [2, "always"]
+    keyword-spacing: [2, {before: true, after: true}]
     space-before-blocks: 2
     space-before-function-paren: [2, "never"]
     space-infix-ops: 2
-    space-return-throw-case: 2
     space-unary-ops: [2, {words: true, nonwords: false}]
     spaced-comment: [2, "always", { exceptions: ["-"]}]
     strict: [2, "global"]

--- a/best_practices/code-analysis/default.eslintrc.yml
+++ b/best_practices/code-analysis/default.eslintrc.yml
@@ -6,6 +6,10 @@ parserOptions:
     ecmaVersion: 6
     sourceType: "module"
 
+plugins: [
+  "babel"
+]
+
 env:
     es6: true
     browser: true
@@ -42,7 +46,7 @@ rules:
     no-fallthrough: 2
     no-floating-decimal: 2
     no-implied-eval: 2
-    no-invalid-this: 2
+    babel/no-invalid-this: 2
     no-iterator: 2
     no-label-var: 2
     no-labels: 2
@@ -72,7 +76,7 @@ rules:
     no-undef: 2
     no-undef-init: 2
     no-undefined: 2
-    no-underscore-dangle: 2
+    no-underscore-dangle: 0
     no-unused-expressions: 2
     no-unused-vars: [2, {vars: "all", args: "after-used", ignoreRestSiblings: false, argsIgnorePattern: '^_'}]
     no-use-before-define: 2

--- a/best_practices/code-analysis/react.eslintrc.yml
+++ b/best_practices/code-analysis/react.eslintrc.yml
@@ -8,6 +8,10 @@ parserOptions:
         jsx: true
     sourceType: "module"
 
+plugins: [
+  "babel"
+]
+
 env:
     es6: true
     browser: true
@@ -44,7 +48,7 @@ rules:
     no-fallthrough: 2
     no-floating-decimal: 2
     no-implied-eval: 2
-    no-invalid-this: 2
+    babel/no-invalid-this: 2
     no-iterator: 2
     no-label-var: 2
     no-labels: 2
@@ -74,7 +78,7 @@ rules:
     no-undef: 2
     no-undef-init: 2
     no-undefined: 2
-    no-underscore-dangle: 2
+    no-underscore-dangle: 0
     no-unused-expressions: 2
     no-unused-vars: [2, {vars: "all", args: "after-used", ignoreRestSiblings: false, argsIgnorePattern: '^_'}]
     no-use-before-define: 2

--- a/best_practices/code-analysis/react.eslintrc.yml
+++ b/best_practices/code-analysis/react.eslintrc.yml
@@ -1,0 +1,107 @@
+extends: ["eslint:recommended", "plugin:react/recommended"]
+
+parser: "babel-eslint"
+
+parserOptions:
+    ecmaVersion: 6
+    ecmaFeatures:
+        jsx: true
+    sourceType: "module"
+
+env:
+    es6: true
+    browser: true
+    node: true
+    jest: true
+    
+rules:
+    indent: ["error", 2, {SwitchCase: 1}]
+    block-spacing: 2
+    brace-style: [2, "1tbs"]
+    camelcase: [2, { properties: "never" }]
+    callback-return: [2, ["cb", "callback", "next"]]
+    comma-spacing: 2
+    comma-style: [2, "last"]
+    consistent-return: 2
+    curly: [2, "all"]
+    default-case: 2
+    dot-notation: [2, { allowKeywords: true }]
+    eol-last: 2
+    eqeqeq: 2
+    func-style: 0
+    guard-for-in: 2
+    key-spacing: [2, { beforeColon: false, afterColon: true }]
+    new-cap: 2
+    new-parens: 2
+    no-alert: 2
+    no-array-constructor: 2
+    no-caller: 2
+    no-console: 0
+    no-delete-var: 2
+    no-eval: 2
+    no-extend-native: 2
+    no-extra-bind: 2
+    no-fallthrough: 2
+    no-floating-decimal: 2
+    no-implied-eval: 2
+    no-invalid-this: 2
+    no-iterator: 2
+    no-label-var: 2
+    no-labels: 2
+    no-lone-blocks: 2
+    no-loop-func: 2
+    no-mixed-spaces-and-tabs: [2, false]
+    no-multi-spaces: 2
+    no-multi-str: 2
+    no-native-reassign: 2
+    no-nested-ternary: 2
+    no-new: 2
+    no-new-func: 2
+    no-new-object: 2
+    no-new-wrappers: 2
+    no-octal: 2
+    no-octal-escape: 2
+    no-process-exit: 2
+    no-proto: 2
+    no-redeclare: 2
+    no-return-assign: 2
+    no-script-url: 2
+    no-sequences: 2
+    no-shadow: 2
+    no-shadow-restricted-names: 2
+    no-spaced-func: 2
+    no-trailing-spaces: 2
+    no-undef: 2
+    no-undef-init: 2
+    no-undefined: 2
+    no-underscore-dangle: 2
+    no-unused-expressions: 2
+    no-unused-vars: [2, {vars: "all", args: "after-used", ignoreRestSiblings: false, argsIgnorePattern: '^_'}]
+    no-use-before-define: 2
+    no-useless-concat: 2
+    no-with: 2
+    quotes: [2, "double"]
+    radix: 2
+    require-jsdoc: 0
+    semi: 2
+    semi-spacing: [2, {before: false, after: true}]
+    keyword-spacing: [2, {before: true, after: true}]
+    space-before-blocks: 2
+    space-before-function-paren: [2, "never"]
+    space-infix-ops: 2
+    space-unary-ops: [2, {words: true, nonwords: false}]
+    spaced-comment: [2, "always", { exceptions: ["-"]}]
+    strict: [2, "global"]
+    valid-jsdoc: [2, { prefer: { "return": "returns"}}]
+    wrap-iife: 2
+    yoda: [2, "never"]
+
+    # Previously on by default in node environment
+    no-catch-shadow: 0
+    # no-console: 0
+    no-mixed-requires: 2
+    no-new-require: 2
+    no-path-concat: 2
+    # no-process-exit: 2
+    global-strict: [0, "always"]
+    handle-callback-err: [2, "err"]


### PR DESCRIPTION
### What does this PR do?

*  Updates the eslint configuration to account for babel sintaxis, previously even though we had the parser set as babel, it was still ignoring the rules for it.
* Does the same for the react eslint configuration.

### Changes to Default configuration
#### Added the plugin for the babel configuration:
Previously even though we had the parser set as babel, it was still ignoring the rules for it.

#### Allows for the use of this inside arrow functions for react components:
`babel/no-invalid-this: 2`

A very usual convention while working with react is using arrow functions to prevent the need of binding `this` every time you need a function. Previously the rule marked code like this as invalid:
``` javascript
  setSelectedAxes = (xAxis, yAxis) => {
    const selectedAxes = { xAxis, yAxis };
    this.props.setSelectedAxes(selectedAxes);
  };
```

#### Turned off underscore dangle:
`no-underscore-dangle: 0`

Sometimes external packages or dependencies break this rule which prevents objects, variables or methods from having underscores at the beginning, so code like this becomes invalid:
```javascript
  object._property;
  object._method();
```

### Discussion
* Should we consider adding a jquery environment flag to prevent the linter from detecting `$` as an invalid global variable?