### PR TITLE
Exclude V1 from Reek's UncommunicativeModuleName check

### DIFF
--- a/best_practices/code-analysis/reek-rails.reek
+++ b/best_practices/code-analysis/reek-rails.reek
@@ -96,7 +96,8 @@ UncommunicativeMethodName:
   accept: []
 UncommunicativeModuleName:
   enabled: true
-  exclude: []
+  exclude:
+  - V1
   reject:
   - !ruby/regexp /^.$/
   - !ruby/regexp /[0-9]$/

--- a/best_practices/code-analysis/reek-rails.reek
+++ b/best_practices/code-analysis/reek-rails.reek
@@ -97,7 +97,7 @@ UncommunicativeMethodName:
 UncommunicativeModuleName:
   enabled: true
   exclude:
-  - V1
+  - !ruby/regexp /\AV(\d+)\z/i
   reject:
   - !ruby/regexp /^.$/
   - !ruby/regexp /[0-9]$/


### PR DESCRIPTION
### What does this PR do?

* Excludes ruby module names such as `V1` from Reek's `UncommunicativeModuleName` check, as it is commonly used for RESTAPI versioning.
