### PR TITLE
Rubocop 1.9.1 config

### DIFF
--- a/best_practices/code-analysis/rubocop/1.9.1/rubocop.yml
+++ b/best_practices/code-analysis/rubocop/1.9.1/rubocop.yml
@@ -1,0 +1,8 @@
+# Given that all configuration inherits from RuboCop's default configuration
+# - see https://docs.rubocop.org/rubocop/configuration.html#inheritance - we
+# will just add corrections over the default configuration instead:
+Metrics/BlockLength:
+  IgnoredMethods:
+    - configure # Ignore the typical configuration blocks
+    - describe  # Ignore RSpec "describe" blocks
+    - context   # Ignore RSpec "context" blocks

--- a/best_practices/code-analysis/rubocop/1.9.1/rubocop.yml
+++ b/best_practices/code-analysis/rubocop/1.9.1/rubocop.yml
@@ -7,3 +7,8 @@ Metrics/BlockLength:
     - describe  # Ignore RSpec "describe" blocks
     - context   # Ignore RSpec "context" blocks
     - namespace # Ignore Rake tasks namespace blocks on lib/tasks folder
+
+# Let's all do Sandi Metz's 5 lines per method thing!
+Metrics/MethodLength:
+  Description: 'Avoid methods longer than 5 lines of code.'
+  Max: 5

--- a/best_practices/code-analysis/rubocop/1.9.1/rubocop.yml
+++ b/best_practices/code-analysis/rubocop/1.9.1/rubocop.yml
@@ -6,3 +6,4 @@ Metrics/BlockLength:
     - configure # Ignore the typical configuration blocks
     - describe  # Ignore RSpec "describe" blocks
     - context   # Ignore RSpec "context" blocks
+    - namespace # Ignore Rake tasks namespace blocks on lib/tasks folder


### PR DESCRIPTION
The latest available RuboCop version on CodeClimate.com is 1.9.1.

We're adding a new couple of new RuboCop configuration files:
- `rubocop-local.yml` that works with local environments (i.e. Visual Studio Code RuboCop extension)
- `rubocop-codeclimate.yml` which disables cops already implemented on CodeClimate maintainability analyzer.